### PR TITLE
Added code to generate ilibmanifest.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/JSONResourceFile.js
+++ b/JSONResourceFile.js
@@ -276,10 +276,10 @@ JSONResourceFile.prototype.write = function() {
 /**
  * Write the manifest file to disk.
  */
-JSONResourceFile.prototype.writeManifest = function(manifestInfo) {
-    logger.info("writing ilibmanifest.json file in [" + this.project.getResourceDirs("json")[0] +"]");
+JSONResourceFile.prototype.writeManifest = function(filePath, manifestInfo) {
+    logger.info("writing ilibmanifest.json file");
     if (!manifestInfo) return;
-    var manifestFilePath = path.join(this.project.getResourceDirs("json")[0], "ilibmanifest.json");
+    var manifestFilePath = path.join(filePath, "ilibmanifest.json");
     fs.writeFileSync(manifestFilePath, JSON.stringify(manifestInfo), 'utf8');
 };
 

--- a/JSONResourceFile.js
+++ b/JSONResourceFile.js
@@ -272,6 +272,17 @@ JSONResourceFile.prototype.write = function() {
     }
 };
 
+
+/**
+ * Write the manifest file to disk.
+ */
+JSONResourceFile.prototype.writeManifest = function(manifestInfo) {
+    logger.info("writing ilibmanifest.json file in [" + this.project.getResourceDirs("json")[0] +"]");
+    if (!manifestInfo) return;
+    var manifestFilePath = path.join(this.project.getResourceDirs("json")[0], "ilibmanifest.json");
+    fs.writeFileSync(manifestFilePath, JSON.stringify(manifestInfo), 'utf8');
+};
+
 /**
  * Return the set of resources found in the current Android
  * resource file.

--- a/JSONResourceFileType.js
+++ b/JSONResourceFileType.js
@@ -198,14 +198,13 @@ JSONResourceFileType.prototype.getPseudo = function() {
 };
 
 /**
- *
+ * Place for additional work after extracting/writing translation data
  */
-
 JSONResourceFileType.prototype.projectClose = function() {
-    var resourcePathInfo = [];
+    var resourcePathInfo = [], manifestContents = {};
     var resourceRoot = this.project.getResourceDirs("json")[0] || "resources";
     var manifestFile = new JSONResourceFile({project: this.project});
-    var manifestContents = {};
+
     for (var hash in this.resourceFiles) {
         path = this.resourceFiles[hash].pathName.replace(resourceRoot + "/","");
         resourcePathInfo.push(path);

--- a/JSONResourceFileType.js
+++ b/JSONResourceFileType.js
@@ -211,6 +211,6 @@ JSONResourceFileType.prototype.projectClose = function() {
     }
 
     manifestContents.files = resourcePathInfo;
-    manifestFile.writeManifest(manifestContents);
+    manifestFile.writeManifest(resourceRoot, manifestContents);
 };
 module.exports = JSONResourceFileType;

--- a/JSONResourceFileType.js
+++ b/JSONResourceFileType.js
@@ -198,7 +198,10 @@ JSONResourceFileType.prototype.getPseudo = function() {
 };
 
 /**
- * Place for additional work after extracting/writing translation data
+ * Called right before each project is closed
+ * Allows the file type class to do any last-minute clean-up or generate any final files
+ *
+ * Generate manifest file based on created resource files
  */
 JSONResourceFileType.prototype.projectClose = function() {
     var resourcePathInfo = [], manifestContents = {};

--- a/JSONResourceFileType.js
+++ b/JSONResourceFileType.js
@@ -32,8 +32,7 @@ var logger = log4js.getLogger("loctool.plugin.JSONResourceFileType");
  * @param {Project} project that this type is in
  */
 var JSONResourceFileType = function(project) {
-    this.parent.call(this,project);
-
+    this.parent.call(this, project);
     this.type = "json";
     this.datatype = "json";
     this.project = project;
@@ -196,5 +195,23 @@ JSONResourceFileType.prototype.getNew = function() {
  */
 JSONResourceFileType.prototype.getPseudo = function() {
     return this.pseudo;
+};
+
+/**
+ *
+ */
+
+JSONResourceFileType.prototype.projectClose = function() {
+    var resourcePathInfo = [];
+    var resourceRoot = this.project.getResourceDirs("json")[0] || "resources";
+    var manifestFile = new JSONResourceFile({project: this.project});
+    var manifestContents = {};
+    for (var hash in this.resourceFiles) {
+        path = this.resourceFiles[hash].pathName.replace(resourceRoot + "/","");
+        resourcePathInfo.push(path);
+    }
+
+    manifestContents.files = resourcePathInfo;
+    manifestFile.writeManifest(manifestContents);
 };
 module.exports = JSONResourceFileType;

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 ilib-loctool-webos-json-resource is a plugin for the loctool that
 allows it to read and localize JSON resource files. This plugins is optimized for webOS platform.
 
+## Release Notes
+
+v1.0.1
+- Updated code to generate `ilibmanifest.json` file not to load unnecessary locale directories.
+  It's implemented in projectClose()
+
 ## License
 
 Copyright © 2019, JEDLSoft

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-json-resource",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "./JSONResourceFileType.js",
     "description": "A loctool plugin that knows how to process JSON resource files",
     "license": "Apache-2.0",


### PR DESCRIPTION

webOS needs `ilibmanifest.json` file not to load unnecessary locale directories.
I've added code to create that file.

**Additional Consideration:**
The first time loctool runs, it should delete the existing ilibmanifest.json file then consider the case if we need to merge the output with other plugin modules.