### PR TITLE
Hot fix :Fixed dependent loctool module version 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ ilib-loctool-webos-json-resource is a plugin for the loctool that
 allows it to read and localize JSON resource files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.3.1
+* Fixed dependent loctool module version
+
 v1.3.0
 * Fixed code in order not to inherit from FileType.
 * Fixed resource target path for the output to go to the project's target location properly.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-json-resource",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "main": "./JSONResourceFileType.js",
     "description": "A loctool plugin that knows how to process JSON resource files",
     "license": "Apache-2.0",
@@ -54,7 +54,7 @@
         "log4js": "^2.11.0"
     },
     "devDependencies": {
-        "loctool": "^2.7.2",
+        "loctool": "2.7.2",
         "nodeunit": "^0.11.3"
     }
 }


### PR DESCRIPTION
Fixed dependent loctool module version
I've published version as 1.3.0.  I realized it checkout the laterst published loctool version.