### PR TITLE
Changed en-US translation to be located in root directory

### DIFF
--- a/JSONResourceFile.js
+++ b/JSONResourceFile.js
@@ -199,11 +199,14 @@ JSONResourceFile.prototype.getContent = function() {
  * @private
  */
 JSONResourceFile.prototype._calcLocalePath = function(locale) {
-    var fullPath = "";
+    var rootLocale = "en-US";
     var splitLocale = this.locale.getSpec().split("-");
+    var fullPath = "";
 
     if (this.baseLocale) {
-        fullPath = "/" + splitLocale[0];
+        if (this.locale.getSpec() !== rootLocale) {
+            fullPath = "/" + splitLocale[0];
+        }
     } else {
         fullPath += "/" + splitLocale.join("/");
     }

--- a/JSONResourceFile.js
+++ b/JSONResourceFile.js
@@ -262,8 +262,10 @@ JSONResourceFile.prototype.write = function() {
         this.API.utils.makeDirs(dir);
 
         var js = this.getContent();
-        fs.writeFileSync(this.pathName, js, "utf8");
-        logger.debug("Wrote string translations to file " + this.pathName);
+        if (js !== "{}") {
+            logger.debug("Wrote string translations to file " + this.pathName);
+            fs.writeFileSync(this.pathName, js, "utf8");
+        }
     } else {
         logger.debug("File " + this.pathName + " is not dirty. Skipping.");
     }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ allows it to read and localize JSON resource files. This plugins is optimized fo
 ## Release Notes
 v1.3.3
 * Changed en-US translation data to be located in the resource root directory
+* Fixed not to generate resource file when the content is empty.
 
 v1.3.2
 * Changed the default Resource output directory to `resources`

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ ilib-loctool-webos-json-resource is a plugin for the loctool that
 allows it to read and localize JSON resource files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.3.3
+* Changed en-US translation data to be located in the resource root directory
+
 v1.3.2
 * Changed the default Resource output directory to `resources`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-json-resource",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "main": "./JSONResourceFileType.js",
     "description": "A loctool plugin that knows how to process JSON resource files",
     "license": "Apache-2.0",

--- a/test/testJSONResourceFile.js
+++ b/test/testJSONResourceFile.js
@@ -470,7 +470,7 @@ module.exports.jsonresourcefile = {
         });
 
         test.ok(jsrf);
-        test.equal(jsrf.getResourceFilePath(), "testfiles/localized_json/en/strings.json");
+        test.equal(jsrf.getResourceFilePath(), "testfiles/localized_json/strings.json");
         test.done();
     },
 
@@ -1017,7 +1017,7 @@ module.exports.jsonresourcefile = {
                     "es-ES","et-EE","fa-IR","fa-AF","fr-FR","fr-CA", "zh-Hans-CN","zh-Hant-HK","zh-Hant-TW"];
 
         var expected = [
-            "testfiles/localized_json/en/strings.json","testfiles/localized_json/en/GB/strings.json",
+            "testfiles/localized_json/strings.json","testfiles/localized_json/en/GB/strings.json",
             "testfiles/localized_json/en/AU/strings.json","testfiles/localized_json/es/CO/strings.json",
             "testfiles/localized_json/es/strings.json","testfiles/localized_json/et/strings.json",
             "testfiles/localized_json/fa/strings.json","testfiles/localized_json/fa/AF/strings.json",

--- a/test/testJSONResourceFilePaths.js
+++ b/test/testJSONResourceFilePaths.js
@@ -190,7 +190,7 @@ module.exports.jsonresourcefilepath = {
             "testfiles/localized_json/en/TW/strings.json",
             "testfiles/localized_json/en/TZ/strings.json",
             "testfiles/localized_json/en/UG/strings.json",
-            "testfiles/localized_json/en/strings.json",
+            "testfiles/localized_json/strings.json",
             "testfiles/localized_json/en/ZA/strings.json",
             "testfiles/localized_json/en/ZM/strings.json",
             "testfiles/localized_json/es/AR/strings.json",
@@ -354,7 +354,7 @@ module.exports.jsonresourcefilepath = {
                     "es-ES","et-EE","fa-IR","fa-AF","fr-FR","fr-CA", "zh-Hans-CN","zh-Hant-HK","zh-Hant-TW"];
 
         var expected = [
-            "testfiles/localized_json/en/cstrings.json","testfiles/localized_json/en/GB/cstrings.json",
+            "testfiles/localized_json/cstrings.json","testfiles/localized_json/en/GB/cstrings.json",
             "testfiles/localized_json/en/AU/cstrings.json","testfiles/localized_json/es/CO/cstrings.json",
             "testfiles/localized_json/es/cstrings.json","testfiles/localized_json/et/cstrings.json",
             "testfiles/localized_json/fa/cstrings.json","testfiles/localized_json/fa/AF/cstrings.json",
@@ -378,7 +378,7 @@ module.exports.jsonresourcefilepath = {
                     "es-ES","et-EE","fa-IR","fa-AF","fr-FR","fr-CA", "hr-HR", "hr-ME", "zh-Hans-CN","zh-Hant-HK","zh-Hant-TW"];
 
         var expected = [
-            "testfiles/resources/en/cppstrings.json","testfiles/resources/en/GB/cppstrings.json",
+            "testfiles/resources/cppstrings.json","testfiles/resources/en/GB/cppstrings.json",
             "testfiles/resources/en/AU/cppstrings.json","testfiles/resources/es/CO/cppstrings.json",
             "testfiles/resources/es/cppstrings.json","testfiles/resources/et/cppstrings.json",
             "testfiles/resources/fa/cppstrings.json","testfiles/resources/fa/AF/cppstrings.json",


### PR DESCRIPTION
* Changed en-US translation data to be located in the resource root directory instead en/
* Fixed not to generate resource file when the content is empty