### PR TITLE
Fix to generate manifest file properly in nested project localization

### DIFF
--- a/JSONResourceFile.js
+++ b/JSONResourceFile.js
@@ -299,7 +299,7 @@ JSONResourceFile.prototype.writeManifest = function(filePath) {
 
     walk(filePath, "");
     for (var i=0; i < manifest.files.length; i++) {
-        logger.info("Writing out", path.join(filePath, manifest.files[i]));
+        logger.info("Writing out", path.join(filePath, manifest.files[i]) + " to Manifest file");
     }
     var manifestFilePath = path.join(filePath, "ilibmanifest.json");
     fs.writeFileSync(manifestFilePath, JSON.stringify(manifest), 'utf8');

--- a/JSONResourceFileType.js
+++ b/JSONResourceFileType.js
@@ -191,7 +191,7 @@ JSONResourceFileType.prototype.getPseudo = function() {
  * Generate manifest file based on created resource files
  */
 JSONResourceFileType.prototype.projectClose = function() {
-    var resourceRoot = this.project.getResourceDirs("json")[0] || "resources";
+    var resourceRoot = path.join(this.project.root, this.project.getResourceDirs("json")[0] || "resources");
     var manifestFile = new JSONResourceFile({project: this.project});
     manifestFile.writeManifest(resourceRoot);
 };

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ allows it to read and localize JSON resource files. This plugins is optimized fo
 
 ## Release Notes
 v1.3.3
-* Changed en-US translation data to be located in the resource root directory
+* Changed en-US translation data to be located in the resource root directory.
 * Fixed not to generate resource file when the content is empty.
+* Fixed to generate `ilibmanifest.json` file properly in the nested project localization case.
 
 v1.3.2
 * Changed the default Resource output directory to `resources`


### PR DESCRIPTION
* Fixed to generate `ilibmanifest.json` file properly in the nested project localization case.