### PR TITLE
Removed source and target comparison when generating resources.

### DIFF
--- a/JSONResourceFile.js
+++ b/JSONResourceFile.js
@@ -20,7 +20,7 @@
 var fs = require("fs");
 var path = require("path");
 var Locale = require("ilib/lib/Locale.js");
-var LocaleMatcher = require("ilib/lib/LocaleMatcher.js");
+var Utils = require("loctool/lib/utils.js");
 
 /**
  * @class Represents an JSON resource file.
@@ -35,15 +35,12 @@ var LocaleMatcher = require("ilib/lib/LocaleMatcher.js");
  * @param {Object} props properties that control the construction of this file.
  */
 var JSONResourceFile = function(props) {
-    var langDefaultLocale;
     this.project = props.project;
     this.locale = new Locale(props.locale);
     this.API = props.project.getAPI();
     this.logger = this.API.getLogger("loctool.plugin.webOSJsonResourceFile");
-    this.minimalLocale = new LocaleMatcher({locale: props.locale}).getLikelyLocaleMinimal().getSpec();
-    langDefaultLocale = new LocaleMatcher({locale: this.locale.language}).getLikelyLocaleMinimal().getSpec();
 
-    this.baseLocale = langDefaultLocale === this.minimalLocale;
+    this.baseLocale = Utils.isBaseLocale(this.locale.getSpec());
     this.set = this.API.newTranslationSet(this.project && this.project.sourceLocale || "en-US");
 };
 
@@ -162,14 +159,10 @@ JSONResourceFile.prototype.getContent = function() {
         for (var j = 0; j < resources.length; j++) {
             var resource = resources[j];
             if (resource.getSource() && resource.getTarget()) {
-                if (clean(resource.getSource()) !== clean(resource.getTarget())) {
-                    this.logger.trace("writing translation for " + resource.getKey() + " as " + resource.getTarget());
-                    json[resource.getKey()] = this.project.settings.identify ?
-                        '<span loclang="javascript" locid="' + resource.getKey() + '">' + resource.getTarget() + '</span>' :
-                        resource.getTarget();
-                } else {
-                    this.logger.trace("skipping translation with no change");
-                }
+                this.logger.trace("writing translation for " + resource.getKey() + " as " + resource.getTarget());
+                json[resource.getKey()] = this.project.settings.identify ?
+                    '<span loclang="javascript" locid="' + resource.getKey() + '">' + resource.getTarget() + '</span>' :
+                    resource.getTarget();
             } else {
                 this.logger.warn("String resource " + resource.getKey() + " has no source text. Skipping...");
             }

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ ilib-loctool-webos-json-resource is a plugin for the loctool that
 allows it to read and localize JSON resource files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.3.11
+* Updated dependencies. (loctool: 2.17.0)
+* Removed source and target comparison code when generating resources.
+  *  en(en-US) (source: Programme , target: Channel)
+  *  en/GB (source: Programme , target: Programme)
+
 v1.3.10
 * Updated dependencies. (loctool: 2.16.3)
 * Used the logger provided by the loctool instead of using log4js directly.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ allows it to read and localize JSON resource files. This plugins is optimized fo
 v1.3.11
 * Updated dependencies. (loctool: 2.17.0)
 * Removed source and target comparison code when generating resources.
-  *  en(en-US) (source: Programme , target: Channel)
-  *  en/GB (source: Programme , target: Programme)
+  *  en(en-US) (source: Programme, target: Channel)
+  *  en/GB (source: Programme, target: Programme)
 
 v1.3.10
 * Updated dependencies. (loctool: 2.16.3)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-json-resource",
-    "version": "1.3.10",
+    "version": "1.3.11",
     "main": "./JSONResourceFileType.js",
     "description": "A loctool plugin that knows how to process JSON resource files",
     "license": "Apache-2.0",
@@ -53,7 +53,7 @@
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "2.16.3",
+        "loctool": "2.17.0",
         "nodeunit": "^0.11.3"
     }
 }

--- a/test/testJSONResourceFile.js
+++ b/test/testJSONResourceFile.js
@@ -1066,7 +1066,7 @@ module.exports.jsonresourcefile = {
 
         var filePath = jsrf.getResourceFilePath();
         var dir = path.dirname(filePath);
-        test.ok(!fs.existsSync(dir));
+        test.ok(fs.existsSync(dir));
         test.ok(jsrf.isDirty());
         test.done();
     }


### PR DESCRIPTION
* Removed source and target comparison code when generating resources.
  * Sample is already added:https://github.com/iLib-js/ilib-loctool-samples/tree/main/webos-js 
  * Issue case example). en/GB/strings.json is needed even though the source and the target are the same.
      en(en-US) (source: Programme , target: Channel)
      en/GB (source: Programme , target: Programme)

* Updated to use loctool's util function instead of implementation here.