### PR TITLE
Update some regarding  manifest file generation

### DIFF
--- a/JSONResourceFile.js
+++ b/JSONResourceFile.js
@@ -1,7 +1,7 @@
 /*
  * JSONResourceFile.js - represents an JSON style resource file
  *
- * Copyright (c) 2019-2022, JEDLSoft
+ * Copyright (c) 2019-2023, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -289,11 +289,14 @@ JSONResourceFile.prototype.writeManifest = function(filePath) {
     }
 
     walk(filePath, "");
-    for (var i=0; i < manifest.files.length; i++) {
-        this.logger.info("Writing out", path.join(filePath, manifest.files[i]) + " to Manifest file");
-    }
     var manifestFilePath = path.join(filePath, "ilibmanifest.json");
-    fs.writeFileSync(manifestFilePath, JSON.stringify(manifest), 'utf8');
+    if (!fs.existsSync(manifestFilePath) && manifest.files.length > 0) {
+        for (var i=0; i < manifest.files.length; i++) {
+            this.logger.info("Writing out", path.join(filePath, manifest.files[i]) + " to Manifest file");
+        }
+        manifest["l10n_timestamp"] = new Date().getTime().toString();
+        fs.writeFileSync(manifestFilePath, JSON.stringify(manifest, undefined, 4), 'utf8');
+    }
 };
 
 /**

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ ilib-loctool-webos-json-resource is a plugin for the loctool that
 allows it to read and localize JSON resource files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.5.0
+* Add to timestampe in `ilibmanifest.json` file to support wee localization
+* Update to skip that writing `ilibmmanifest json` creation logic if it has already been done in another plugin.
+
 v1.4.2
 * Updated dependent module version to have the latest one.(loctool: 2.20.2)
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ allows it to read and localize JSON resource files. This plugins is optimized fo
 
 ## Release Notes
 v1.5.0
-* Add to timestampe in `ilibmanifest.json` file to support wee localization
-* Update to skip that writing `ilibmmanifest json` creation logic if it has already been done in another plugin.
+* Added to timestampe in `ilibmanifest.json` file to support wee localization.
+* Updated to skip writing `ilibmmanifest json` creation logic if it has already been done in another plugin.
 
 v1.4.2
 * Updated dependent module version to have the latest one.(loctool: 2.20.2)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-json-resource",
-    "version": "1.4.2",
+    "version": "1.5.0",
     "main": "./JSONResourceFileType.js",
     "description": "A loctool plugin that knows how to process JSON resource files",
     "license": "Apache-2.0",
@@ -49,7 +49,7 @@
         "node": ">=10.0.0"
     },
     "dependencies": {
-        "ilib": "^14.16.0"
+        "ilib": "^14.17.0"
     },
     "devDependencies": {
         "assertextras": "^1.1.0",


### PR DESCRIPTION
* Added to timestamp in `ilibmanifest.json` file to support wee localization.
* Updated to skip writing `ilibmmanifest json` creation logic if it has already been done in another plugin.
* Set to have more spaces in `ilibmanifest.json` file.