### PR TITLE
Fix to generate manifest file correctly even when a dummy file exists #37

### DIFF
--- a/JSONResourceFile.js
+++ b/JSONResourceFile.js
@@ -290,11 +290,17 @@ JSONResourceFile.prototype.writeManifest = function(filePath) {
 
     walk(filePath, "");
     var manifestFilePath = path.join(filePath, "ilibmanifest.json");
-    if (!fs.existsSync(manifestFilePath) && manifest.files.length > 0) {
+    var readManifest, data;
+    if (fs.existsSync(manifestFilePath)) {
+        readManifest = fs.readFileSync(manifestFilePath, {encoding:'utf8'});
+        data = JSON.parse(readManifest)
+    }
+    if ((!data || data["generated"] === undefined) && manifest.files.length > 0) {
         for (var i=0; i < manifest.files.length; i++) {
             this.logger.info("Writing out", path.join(filePath, manifest.files[i]) + " to Manifest file");
         }
         manifest["l10n_timestamp"] = new Date().getTime().toString();
+        manifest["generated"] = true;
         fs.writeFileSync(manifestFilePath, JSON.stringify(manifest, undefined, 4), 'utf8');
     }
 };

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ ilib-loctool-webos-json-resource is a plugin for the loctool that
 allows it to read and localize JSON resource files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.5.1
+* Fixed to generate `ilibmanifest.json` file correctly even when a dummy file exists.
+
 v1.5.0
 * Added a timestamp in `ilibmanifest.json` file to support wee localization.
 * Updated to skip writing `ilibmanifest.json` creation logic if it has already been done in another plugin.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-json-resource",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "main": "./JSONResourceFileType.js",
     "description": "A loctool plugin that knows how to process JSON resource files",
     "license": "Apache-2.0",


### PR DESCRIPTION
Fixed to generate `ilibmanifest.json` file correctly even when a dummy file exists.