### PR TITLE
Update peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This plugin is license under Apache2. See the [LICENSE](./LICENSE)
 file for more details.
 
 ## Release Notes
+### v1.6.1
+* Updated dependencies. (loctool: 2.24.0)
 
 ### v1.6.0
 * Updated to support Dart filetype localization output.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-json-resource",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "main": "./JSONResourceFileType.js",
     "description": "A loctool plugin that knows how to process JSON resource files",
     "license": "Apache-2.0",
@@ -53,7 +53,7 @@
         "ilib": "^14.19.0"
     },
     "peerDependencies": {
-        "loctool": "2.23.1"
+        "loctool": "2.24.0"
     },
     "devDependencies": {
         "jest": "^26.6.3",


### PR DESCRIPTION
Forgot to update peerDependencies's loctool version.
Published the package version (v1.6.0) has been deprecated.