### PR TITLE
Updated to generate the plural pseudo data for the DartFileType correctly.

### DIFF
--- a/JSONResourceFile.js
+++ b/JSONResourceFile.js
@@ -21,7 +21,7 @@ var fs = require("fs");
 var path = require("path");
 var Locale = require("ilib/lib/Locale.js");
 var Utils = require("loctool/lib/utils.js");
-
+var PseudoFactory = require("loctool/lib/PseudoFactory.js");
 /**
  * @class Represents an JSON resource file.
  * The props may contain any of the following properties:
@@ -160,17 +160,16 @@ JSONResourceFile.prototype._isPluralData = function(data) {
 /**
  * @private
  */
-JSONResourceFile.prototype._parsePluralData = function(data) {
+JSONResourceFile.prototype._parsePluralData = function(data, locale) {
     var parsePlural = {};
     var categoryMap = {
         "0" : "zero",
         "1" : "one",
         "2" : "two"
     }
-    var isPseudoString = false;
-    if (data.startsWith("[")) {
-        // pseudo string
-        isPseudoString = true;
+    var pseudoLocale = PseudoFactory.isPseudoLocale(locale, this.project);
+
+    if (pseudoLocale) {
         data = data.substr(1,data.length-2);
     }
     var splitData = data.split("|");
@@ -179,7 +178,7 @@ JSONResourceFile.prototype._parsePluralData = function(data) {
             var parse = item.split("#");
             if (categoryMap[parse[0]] !== undefined) parse[0] = categoryMap[parse[0]];
             if (parse[0] === '') parse[0] = "other";
-            parsePlural[parse[0]] = (isPseudoString) ? "[" + parse[1] + "]" : parse[1];
+            parsePlural[parse[0]] = (pseudoLocale) ? "[" + parse[1] + "]" : parse[1];
 
         }.bind(this));
     }
@@ -207,7 +206,7 @@ JSONResourceFile.prototype.getContent = function() {
             var resource = resources[j];
             var result = this._isPluralData(resource.getTarget());
             if (result) {
-                var data = this._parsePluralData(resource.getTarget());
+                var data = this._parsePluralData(resource.getTarget(), resource.getTargetLocale());
                 resource.setTarget(data);
             }
 

--- a/JSONResourceFile.js
+++ b/JSONResourceFile.js
@@ -161,23 +161,28 @@ JSONResourceFile.prototype._isPluralData = function(data) {
  * @private
  */
 JSONResourceFile.prototype._parsePluralData = function(data) {
-    var splitData = data.split("|");
     var parsePlural = {};
     var categoryMap = {
         "0" : "zero",
         "1" : "one",
         "2" : "two"
-    } 
+    }
+    var isPseudoString = false;
+    if (data.startsWith("[")) {
+        // pseudo string
+        isPseudoString = true;
+        data = data.substr(1,data.length-2);
+    }
+    var splitData = data.split("|");
     if (splitData.length > 0) {
         splitData.forEach(function(item){
             var parse = item.split("#");
             if (categoryMap[parse[0]] !== undefined) parse[0] = categoryMap[parse[0]];
             if (parse[0] === '') parse[0] = "other";
-            parsePlural[parse[0]] = parse[1];
+            parsePlural[parse[0]] = (isPseudoString) ? "[" + parse[1] + "]" : parse[1];
 
         }.bind(this));
     }
-
     return parsePlural;
 };
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ file for more details.
 
 ## Release Notes
 ### v1.7.0
-* Update to generate the plural pseudo data for the DartFileType correctly.
+* Updated to generate the plural pseudo data for the DartFileType correctly.
 
 ### v1.6.1
 * Updated dependencies. (loctool: 2.24.0)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ This plugin is license under Apache2. See the [LICENSE](./LICENSE)
 file for more details.
 
 ## Release Notes
+### v1.7.0
+* Update to generate the plural pseudo data for the DartFileType correctly.
+
 ### v1.6.1
 * Updated dependencies. (loctool: 2.24.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-json-resource",
-    "version": "1.6.1",
+    "version": "1.7.0",
     "main": "./JSONResourceFileType.js",
     "description": "A loctool plugin that knows how to process JSON resource files",
     "license": "Apache-2.0",
@@ -50,7 +50,7 @@
         "node": ">=10.0.0"
     },
     "dependencies": {
-        "ilib": "^14.19.0"
+        "ilib": "^14.20.0"
     },
     "peerDependencies": {
         "loctool": "2.24.0"


### PR DESCRIPTION
* Updated to generate the plural pseudo data for the Dart FileType correctly.

e.g.)

AS-IS (zxx.json):
```
"1#At least 1 letter|#At least {num} letters": {
     "[1": "Ãţ ľëàšţ 1 ľëţţëŕ",
     "other": "Ãţ ľëàšţ {num} ľëţţëŕš876543210]"
},
```
TO-BE (zxx.json):
```
"1#At least 1 letter|#At least {num} letters": {
     "one": "[Ãţ ľëàšţ 1 ľëţţëŕ]",
     "other": "[Ãţ ľëàšţ {num} ľëţţëŕš876543210]"
},
```